### PR TITLE
**PR Summary: macOS Radio Deploy + Serial Debug Enablement**

### DIFF
--- a/lua/vscode-project/.gitattributes
+++ b/lua/vscode-project/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/lua/vscode-project/.vscode/launch.json
+++ b/lua/vscode-project/.vscode/launch.json
@@ -79,8 +79,30 @@
       "stopOnEntry": false,
       "preLaunchTask": "Radio: Serial Debug"
     },
+   {
+      "name": "Simulator: Open Controls",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/.vscode/scripts/dummy.py",
+      "console": "integratedTerminal",
+      "subProcess": false,
+      "justMyCode": true,
+      "stopOnEntry": false,
+      "preLaunchTask": "ethos.OpenControls"
+    },
     {
-      "name": "Clear locks",
+      "name": "Simulator: Open Telemetry",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/.vscode/scripts/dummy.py",
+      "console": "integratedTerminal",
+      "subProcess": false,
+      "justMyCode": true,
+      "stopOnEntry": false,
+      "preLaunchTask": "ethos.OpenTelemetry"
+    },    
+    {
+      "name": "Simulator: Clear Locks",
       "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/.vscode/scripts/dummy.py",

--- a/lua/vscode-project/.vscode/scripts/connect.py
+++ b/lua/vscode-project/.vscode/scripts/connect.py
@@ -25,7 +25,7 @@ from connect_base import RadioInformation
 # Select platform-specific implementation
 if platform.system() == "Windows":
     from connect_windows import WindowsRadioInterface as RadioInterface, lock_drive, unmount_drive
-else:
+elif platform.system() == "Darwin":
     from connect_macos import MacOSRadioInterface as RadioInterface
     # Provide no-op implementations for macOS (locking not supported)
     def lock_drive(drive):
@@ -35,6 +35,8 @@ else:
     def unmount_drive(drive):
         """Unmount via diskutil; called by RadioInterface.unmount_drives()."""
         pass
+else:
+    raise SystemExit("System/OS not yet supported")
 
 
 

--- a/lua/vscode-project/.vscode/scripts/connect.py
+++ b/lua/vscode-project/.vscode/scripts/connect.py
@@ -1,190 +1,77 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+"""
+Ethos Radio USB HID and deployment interface (cross-platform).
 
-from dataclasses import dataclass
+This module provides a unified interface for radio control on Windows and macOS.
+Platform-specific drive management is handled by connect_windows.py or connect_macos.py.
+
+Public API (stable across platforms):
+  - RadioInterface: Main class for radio HID control and drive discovery
+  - RadioInformation: Dataclass with board and storage info
+  - flash_device(): Flash a .frsk device file
+  - flash_firmware(): Flash a firmware.bin image
+"""
+
 import os
-import time
-import argparse
-import ctypes
-import ctypes.wintypes as wintypes
-from ctypes import windll
-import win32api
-import win32file
+import platform
 import shutil
+import argparse
+import time
 
-try:
-    import hid
-except ModuleNotFoundError:
-    print("Error: hid module needed, you may use this command 'python -m pip install hid'")
-    exit(-1)
-except ImportError:
-    print("Error: hidapi.dll is missing, you need to copy it from this project https://github.com/libusb/hidapi to C:\\Windows\\System32\\")
-    exit(-1)
+# Import base and platform-independent constants
+from connect_base import RadioInformation
 
-GENERIC_READ = 0x80000000
-GENERIC_WRITE = 0x40000000
-FILE_SHARE_READ = 0x00000001
-FILE_SHARE_WRITE = 0x00000002
-OPEN_EXISTING = 3
-FSCTL_LOCK_VOLUME = 0x00090018
-FSCTL_UNLOCK_VOLUME = 0x0009001c
-FSCTL_DISMOUNT_VOLUME = 0x00090020
-IOCTL_STORAGE_MEDIA_REMOVAL = 0x002d4804
-IOCTL_STORAGE_EJECT_MEDIA = 0x002d4808
-FILE_ATTRIBUTE_NORMAL = 0x00000080
-INVALID_HANDLE_VALUE = -1
+# Select platform-specific implementation
+if platform.system() == "Windows":
+    from connect_windows import WindowsRadioInterface as RadioInterface, lock_drive, unmount_drive
+else:
+    from connect_macos import MacOSRadioInterface as RadioInterface
+    # Provide no-op implementations for macOS (locking not supported)
+    def lock_drive(drive):
+        """No-op on macOS: volume locking via FSCTL is not available."""
+        pass
+
+    def unmount_drive(drive):
+        """Unmount via diskutil; called by RadioInterface.unmount_drives()."""
+        pass
 
 
-def fsctl_drive(drive, commands):
-    handle = windll.kernel32.CreateFileW(
-            ctypes.c_wchar_p(r'\\.\%s' % drive),
-            GENERIC_READ | GENERIC_WRITE,
-            FILE_SHARE_READ | FILE_SHARE_WRITE,
-            0,
-            OPEN_EXISTING,
-            FILE_ATTRIBUTE_NORMAL,
-            0)
-    if handle != INVALID_HANDLE_VALUE:
-        for command in commands:
-            bytes_returned = wintypes.DWORD()
-            inBuffer = wintypes.DWORD()
-            retry = 10
-            while retry > 0:
-                status = windll.kernel32.DeviceIoControl(handle, command, ctypes.byref(inBuffer), 4, None, 0, ctypes.byref(bytes_returned), 0)
-                if status > 0:
-                    break
-                retry -= 1
-                if retry > 0:
-                    print("DiskIoControl(%s, %X) failed, retrying after 1 second ..." % (drive, command))
-                    time.sleep(1)
-                else:
-                    print("DiskIoControl(%s, %X) failed" % (drive, command))
-    else:
-        print("Open drive %s failed" % drive)
+
+def flash_device(frsk):
+    """Flash a .frsk device file."""
+    print("Copy frsk to radio...")
+    radio = RadioInterface()
+    information = radio.request_information()
+    storage_key = information.default_storage
+    drive = radio.drives.get(storage_key)
+    if not drive:
+        raise RuntimeError(f"Radio storage '{storage_key}' not found in {radio.drives}")
+    shutil.copy(frsk, os.path.join(drive, "device.frsk"))
+    print("Lock the drive...")
+    lock_drive(drive)
+    print("Flash...")
+    radio.flash_frsk()
 
 
-def unmount_drive(drive):
-    fsctl_drive(drive, [FSCTL_LOCK_VOLUME, FSCTL_DISMOUNT_VOLUME, IOCTL_STORAGE_MEDIA_REMOVAL, IOCTL_STORAGE_EJECT_MEDIA])
-
-
-def lock_drive(drive):
-    fsctl_drive(drive, [FSCTL_LOCK_VOLUME])
-
-
-ETHOS_SUITE_INFORMATION_REQUEST = 0x21
-ETHOS_SUITE_INFORMATION_RESPONSE = 0x22
-ETHOS_SUITE_FLASH_FIRMWARE_REQUEST = 0x41
-ETHOS_SUITE_FLASH_FIRMWARE_RESPONSE = 0x42
-ETHOS_SUITE_FLASH_FRSK_REQUEST = 0x51
-ETHOS_SUITE_FLASH_FRSK_RESPONSE = 0x52
-ETHOS_SUITE_REBOOT_REQUEST = 0x61
-ETHOS_SUITE_FORMAT_STORAGE_REQUEST = 0x71
-ETHOS_SUITE_FORMAT_STORAGE_RESPONSE = 0x72
-ETHOS_SUITE_USB_MODE_REQUEST = 0x81
-ETHOS_SUITE_USB_MODE_RESPONSE = 0x82
-
-
-@dataclass
-class RadioInformation:
-    board: int
-    default_storage: str  
-
-
-class RadioInterface(hid.Device):
-    def __init__(self, retries=10, retry_delay=0.5):
-        last_error = None
-
-        for attempt in range(1, retries + 1):
-            try:
-                hid.Device.__init__(self, vid=0x0483, pid=0x5750)
-                break
-            except hid.HIDException as e:
-                last_error = e
-                if attempt < retries:
-                    time.sleep(retry_delay)
-                else:
-                    print("Error: No Ethos compatible device found!")
-                    exit(-1)
-
-        # Give Windows a moment to finish mounting volumes
-        time.sleep(1)
-
-        self.drives = {}
-        self._scan_drives_internal()
-
-    def unmount_drives(self):
-        for drive in self.drives.values():
-            unmount_drive(drive)
-
-    def request_information(self):
-        self.write(bytes([0x00, ETHOS_SUITE_INFORMATION_REQUEST, 6]))
-        result = self.read(256, 200)
-        if result:
-            # print([hex(b) for b in result])
-            board = result[2]
-            return RadioInformation(
-                board = board,
-                default_storage = "sdcard" if board in [4, 5, 6, 11] else "radio",
-            )
-
-    def reboot_firmware(self):
-        self.write(bytes([0x00, ETHOS_SUITE_REBOOT_REQUEST, 0x66]))
-
-    def start_usb_debug(self):
-        self.unmount_drives()
-        self.write(bytes([0x00, ETHOS_SUITE_USB_MODE_REQUEST, 0x68]))
-    
-    def stop_usb_debug(self):
-        self.write(bytes([0x00, ETHOS_SUITE_USB_MODE_REQUEST, 0x69]))
-
-    def flash_frsk(self):
-        self.write(bytes([0x00, ETHOS_SUITE_FLASH_FRSK_REQUEST]))
-
-    def flash_firmware(self):
-        self.write(bytes([0x00, ETHOS_SUITE_FLASH_FIRMWARE_REQUEST]))
-
-    def _scan_drives_internal(self):
-        """
-        Scan removable drives for Ethos cpuid markers and populate self.drives.
-        """
-        self.drives = {}
-
-        for drive in win32api.GetLogicalDriveStrings().split('\x00')[:-1]:
-            dtype = win32file.GetDriveType(drive)
-            if dtype != win32file.DRIVE_REMOVABLE:
-                continue
-
-            for key in ('flash', 'sdcard', 'radio'):
-                if os.path.exists(os.path.join(drive, key + ".cpuid")):
-                    # Normalise like existing code (e.g. 'H:')
-                    self.drives[key] = drive.replace("\\", "")
-
-    def scan_for_drives(self):
-        """
-        Public API for deploy tooling.
-        Rescans removable drives and returns self.drives.
-        """
-        self._scan_drives_internal()
-        return self.drives
-
-    def get_scripts_dir(self):
-        """
-        Return the mounted scripts directory, or None.
-        """
-        self.scan_for_drives()
-
-        # Prefer sdcard / radio over flash
-        for key in ("sdcard", "radio", "flash"):
-            root = self.drives.get(key)
-            if root:
-                scripts = os.path.join(root, "scripts")
-                if os.path.isdir(scripts):
-                    return os.path.normpath(scripts)
-
-        return None
+def flash_firmware(firmware):
+    """Flash a firmware.bin image."""
+    print("Copy firmware to radio...")
+    radio = RadioInterface()
+    information = radio.request_information()
+    storage_key = information.default_storage
+    drive = radio.drives.get(storage_key)
+    if not drive:
+        raise RuntimeError(f"Radio storage '{storage_key}' not found in {radio.drives}")
+    shutil.copy(firmware, os.path.join(drive, "firmware.bin"))
+    print("Lock the drive...")
+    lock_drive(drive)
+    print("Flash...")
+    radio.flash_firmware()
 
 
 def massstorage_test():
+    """Test mass storage mode switching."""
     index = 0
     while True:
         index += 1
@@ -195,33 +82,11 @@ def massstorage_test():
         print("  start the debug session during 30s ...")
         radio.start_usb_debug()
         time.sleep(10)
-        
+
         print("  stop the debug session ...")
         radio = RadioInterface()
         radio.stop_usb_debug()
         time.sleep(1)
-
-
-def flash_device(frsk):
-    print("Copy frsk to radio...")
-    radio = RadioInterface()
-    information = radio.request_information()
-    shutil.copy(frsk, radio.drives[information.default_storage] + "/device.frsk")
-    print("Lock the drive...")
-    lock_drive(radio.drives[information.default_storage])
-    print("Flash...")
-    radio.flash_frsk()
-
-
-def flash_firmware(firmware):
-    print("Copy firmware to radio...")
-    radio = RadioInterface()
-    information = radio.request_information()
-    shutil.copy(firmware, radio.drives[information.default_storage] + "/firmware.bin")
-    print("Lock the drive...")
-    lock_drive(radio.drives[information.default_storage])
-    print("Flash...")
-    radio.flash_firmware()
 
 
 def main():

--- a/lua/vscode-project/.vscode/scripts/connect_base.py
+++ b/lua/vscode-project/.vscode/scripts/connect_base.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Cross-platform HID protocol and state management for Ethos radio.
+
+This module contains the platform-neutral RadioInterface base class and
+the HID protocol constants. Platform-specific drive management is delegated
+to connect_windows.py or connect_macos.py.
+"""
+
+from dataclasses import dataclass
+import time
+
+try:
+    import hid
+except ModuleNotFoundError:
+    raise ImportError("hid module needed; install with: python -m pip install hid")
+except ImportError:
+    raise ImportError("hidapi library is missing. On macOS, run: brew install hidapi")
+
+
+# HID Protocol Constants
+ETHOS_SUITE_INFORMATION_REQUEST = 0x21
+ETHOS_SUITE_INFORMATION_RESPONSE = 0x22
+ETHOS_SUITE_FLASH_FIRMWARE_REQUEST = 0x41
+ETHOS_SUITE_FLASH_FIRMWARE_RESPONSE = 0x42
+ETHOS_SUITE_FLASH_FRSK_REQUEST = 0x51
+ETHOS_SUITE_FLASH_FRSK_RESPONSE = 0x52
+ETHOS_SUITE_REBOOT_REQUEST = 0x61
+ETHOS_SUITE_FORMAT_STORAGE_REQUEST = 0x71
+ETHOS_SUITE_FORMAT_STORAGE_RESPONSE = 0x72
+ETHOS_SUITE_USB_MODE_REQUEST = 0x81
+ETHOS_SUITE_USB_MODE_RESPONSE = 0x82
+
+ETHOS_VENDOR_ID = 0x0483
+# 0x5750 is the expected HID endpoint for Ethos USB mode control.
+# 0x5740 is seen on some devices/firmware states during re-enumeration.
+ETHOS_PRODUCT_IDS = (0x5750, 0x5740)
+
+
+@dataclass
+class RadioInformation:
+    board: int
+    default_storage: str
+
+
+class RadioInterfaceBase(hid.Device):
+    """
+    Base class: HID communication with Ethos radio.
+
+    Handles USB HID protocol for mode switching and device queries.
+    Platform-specific drive discovery and management is delegated to
+    subclasses via the drive_manager interface.
+    """
+
+    def __init__(self, retries=10, retry_delay=0.5):
+        last_error = None
+
+        for attempt in range(1, retries + 1):
+            try:
+                self._open_ethos_hid_device()
+                break
+            except Exception as e:
+                last_error = e
+                if attempt < retries:
+                    time.sleep(retry_delay)
+                else:
+                    summary = self._summarize_ethos_candidates()
+                    raise RuntimeError(f"No Ethos compatible HID device found ({summary})") from last_error
+
+        # Give the platform a moment to finish enumerating/mounting
+        time.sleep(1)
+
+        self.drives = {}
+
+    def _open_ethos_hid_device(self):
+        """Open the Ethos HID interface using resilient probing strategies."""
+        # Strategy 1: direct VID/PID open for known product IDs.
+        for pid in ETHOS_PRODUCT_IDS:
+            try:
+                hid.Device.__init__(self, vid=ETHOS_VENDOR_ID, pid=pid)
+                return
+            except Exception:
+                pass
+
+        # Strategy 2: enumerate interfaces and open by exact device path.
+        for dev in self._ethos_candidates_from_enumerate():
+            path = dev.get("path")
+            if not path:
+                continue
+            try:
+                hid.Device.__init__(self, path=path)
+                return
+            except Exception:
+                continue
+
+        # Strategy 3: last-chance open by any enumerated vendor product id.
+        for dev in self._ethos_candidates_from_enumerate():
+            pid = dev.get("product_id")
+            if pid is None:
+                continue
+            try:
+                hid.Device.__init__(self, vid=ETHOS_VENDOR_ID, pid=pid)
+                return
+            except Exception:
+                continue
+
+        raise RuntimeError("HID open failed for all Ethos candidates")
+
+    def _ethos_candidates_from_enumerate(self):
+        """Return HID enumerate rows that look like Ethos devices."""
+        candidates = []
+        try:
+            for dev in hid.enumerate():
+                if dev.get("vendor_id") != ETHOS_VENDOR_ID:
+                    continue
+                pid = dev.get("product_id")
+                usage_page = dev.get("usage_page")
+                interface_number = dev.get("interface_number")
+
+                # Prefer known Ethos PIDs; otherwise accept likely HID control interfaces.
+                if pid in ETHOS_PRODUCT_IDS:
+                    candidates.append(dev)
+                    continue
+
+                if usage_page in (0xFF00, 0x0001, 0x000C) or interface_number in (0, 1):
+                    candidates.append(dev)
+        except Exception:
+            return []
+        return candidates
+
+    def _summarize_ethos_candidates(self):
+        """Build a compact diagnostic summary for detection failures."""
+        try:
+            all_0483 = [d for d in hid.enumerate() if d.get("vendor_id") == ETHOS_VENDOR_ID]
+            pids = sorted({d.get("product_id") for d in all_0483 if d.get("product_id") is not None})
+            if not all_0483:
+                return "vendor 0x0483 not present"
+            if not pids:
+                return f"vendor present ({len(all_0483)} interfaces), pid unknown"
+            pid_text = ",".join(f"0x{p:04X}" for p in pids)
+            return f"vendor present ({len(all_0483)} interfaces), pids={pid_text}"
+        except Exception:
+            return "unable to enumerate HID devices"
+
+    def request_information(self):
+        """Query radio board and storage info via HID."""
+        self.write(bytes([0x00, ETHOS_SUITE_INFORMATION_REQUEST, 6]))
+        result = self.read(256, 200)
+        if result:
+            board = result[2]
+            return RadioInformation(
+                board=board,
+                default_storage="sdcard" if board in [4, 5, 6, 11] else "radio",
+            )
+        return None
+
+    def reboot_firmware(self):
+        """Reboot the radio firmware via HID."""
+        self.write(bytes([0x00, ETHOS_SUITE_REBOOT_REQUEST, 0x66]))
+
+    def start_usb_debug(self):
+        """Switch radio to USB debug (serial) mode via HID."""
+        unmount = getattr(self, "unmount_drives", None)
+        if callable(unmount):
+            try:
+                unmount()
+            except Exception:
+                # Best-effort: still try the HID mode switch even if unmount fails.
+                pass
+        self.write(bytes([0x00, ETHOS_SUITE_USB_MODE_REQUEST, 0x68]))
+
+    def stop_usb_debug(self):
+        """Switch radio to mass-storage mode via HID."""
+        self.write(bytes([0x00, ETHOS_SUITE_USB_MODE_REQUEST, 0x69]))
+
+    def flash_frsk(self):
+        """Trigger .frsk flash via HID."""
+        self.write(bytes([0x00, ETHOS_SUITE_FLASH_FRSK_REQUEST]))
+
+    def flash_firmware(self):
+        """Trigger firmware flash via HID."""
+        self.write(bytes([0x00, ETHOS_SUITE_FLASH_FIRMWARE_REQUEST]))

--- a/lua/vscode-project/.vscode/scripts/connect_macos.py
+++ b/lua/vscode-project/.vscode/scripts/connect_macos.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+macOS-specific drive management for Ethos radio deployment.
+
+Discovers radio volumes by scanning /Volumes for .cpuid markers.
+Eject operations use diskutil. Volume locking is not available on macOS
+(no FSCTL_LOCK_VOLUME equivalent), but is not strictly needed since the
+deployment workflow is sequential and user-initiated.
+"""
+
+import os
+import subprocess
+from connect_base import RadioInterfaceBase, RadioInformation
+
+
+class MacOSRadioInterface(RadioInterfaceBase):
+    """macOS implementation: drive discovery via /Volumes scanning."""
+
+    def __init__(self, retries=10, retry_delay=0.5):
+        super().__init__(retries=retries, retry_delay=retry_delay)
+        self._scan_drives_internal()
+
+    def unmount_drives(self):
+        """
+        Unmount all discovered drives using diskutil.
+
+        On macOS, we first unmount mounted volumes so the radio can switch away
+        from mass-storage mode. This is best-effort.
+        Volume locking (Windows FSCTL_LOCK_VOLUME) is not available on macOS,
+        but is not critical for the sequential, user-initiated deployment workflow.
+        """
+        for drive in sorted(set(self.drives.values())):
+            try:
+                result = subprocess.run(
+                    ["diskutil", "unmount", drive],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                if result.returncode != 0:
+                    subprocess.run(
+                        ["diskutil", "eject", drive],
+                        capture_output=True,
+                        text=True,
+                        timeout=5,
+                    )
+            except Exception as e:
+                print(f"[macOS] diskutil unmount/eject {drive} failed ({type(e).__name__}: {e}); continuing anyway.")
+
+    def _scan_drives_internal(self):
+        """
+        Scan /Volumes for Ethos cpuid markers and populate self.drives.
+
+        On macOS, removable volumes are mounted under /Volumes.
+        We check for flash.cpuid, sdcard.cpuid, and radio.cpuid markers
+        to identify Ethos radio storage partitions.
+        """
+        self.drives = {}
+
+        volumes_dir = "/Volumes"
+        if not os.path.isdir(volumes_dir):
+            return
+
+        try:
+            entries = os.listdir(volumes_dir)
+        except OSError:
+            return
+
+        for entry in entries:
+            volume_path = os.path.join(volumes_dir, entry)
+
+            # Skip if not a directory or if it's a system volume
+            if not os.path.isdir(volume_path):
+                continue
+
+            for key in ('flash', 'sdcard', 'radio'):
+                cpuid_marker = os.path.join(volume_path, key + ".cpuid")
+                if os.path.exists(cpuid_marker):
+                    # Store the volume path (normalized)
+                    self.drives[key] = os.path.normpath(volume_path)
+
+    def scan_for_drives(self):
+        """
+        Public API for deploy tooling.
+        Rescans /Volumes for cpuid markers and returns self.drives.
+        """
+        self._scan_drives_internal()
+        return self.drives
+
+    def get_scripts_dir(self):
+        """Return the mounted scripts directory, or None."""
+        self.scan_for_drives()
+
+        # Prefer sdcard / radio over flash
+        for key in ("sdcard", "radio", "flash"):
+            root = self.drives.get(key)
+            if root:
+                scripts = os.path.join(root, "scripts")
+                if os.path.isdir(scripts):
+                    return os.path.normpath(scripts)
+
+        return None

--- a/lua/vscode-project/.vscode/scripts/connect_windows.py
+++ b/lua/vscode-project/.vscode/scripts/connect_windows.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Windows-specific drive management for Ethos radio deployment.
+
+Uses win32api, win32file, and ctypes to query and control removable volumes.
+"""
+
+import os
+import time
+import ctypes
+import ctypes.wintypes as wintypes
+from ctypes import windll
+
+import win32api
+import win32file
+
+from connect_base import RadioInterfaceBase, RadioInformation
+
+
+# Windows drive control constants
+GENERIC_READ = 0x80000000
+GENERIC_WRITE = 0x40000000
+FILE_SHARE_READ = 0x00000001
+FILE_SHARE_WRITE = 0x00000002
+OPEN_EXISTING = 3
+FSCTL_LOCK_VOLUME = 0x00090018
+FSCTL_UNLOCK_VOLUME = 0x0009001c
+FSCTL_DISMOUNT_VOLUME = 0x00090020
+IOCTL_STORAGE_MEDIA_REMOVAL = 0x002d4804
+IOCTL_STORAGE_EJECT_MEDIA = 0x002d4808
+FILE_ATTRIBUTE_NORMAL = 0x00000080
+INVALID_HANDLE_VALUE = -1
+
+
+def fsctl_drive(drive, commands):
+    """Send FSCTL commands to a Windows drive."""
+    handle = windll.kernel32.CreateFileW(
+        ctypes.c_wchar_p(r'\\.\%s' % drive),
+        GENERIC_READ | GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        0,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        0)
+    if handle != INVALID_HANDLE_VALUE:
+        for command in commands:
+            bytes_returned = wintypes.DWORD()
+            inBuffer = wintypes.DWORD()
+            retry = 10
+            while retry > 0:
+                status = windll.kernel32.DeviceIoControl(handle, command, ctypes.byref(inBuffer), 4, None, 0, ctypes.byref(bytes_returned), 0)
+                if status > 0:
+                    break
+                retry -= 1
+                if retry > 0:
+                    print("DiskIoControl(%s, %X) failed, retrying after 1 second ..." % (drive, command))
+                    time.sleep(1)
+                else:
+                    print("DiskIoControl(%s, %X) failed" % (drive, command))
+    else:
+        print("Open drive %s failed" % drive)
+
+
+def unmount_drive(drive):
+    """Unmount a Windows drive using FSCTL commands."""
+    fsctl_drive(drive, [FSCTL_LOCK_VOLUME, FSCTL_DISMOUNT_VOLUME, IOCTL_STORAGE_MEDIA_REMOVAL, IOCTL_STORAGE_EJECT_MEDIA])
+
+
+def lock_drive(drive):
+    """Lock a Windows drive using FSCTL_LOCK_VOLUME."""
+    fsctl_drive(drive, [FSCTL_LOCK_VOLUME])
+
+
+class WindowsRadioInterface(RadioInterfaceBase):
+    """Windows implementation: drive management via win32 APIs."""
+
+    def __init__(self, retries=10, retry_delay=0.5):
+        super().__init__(retries=retries, retry_delay=retry_delay)
+        self._scan_drives_internal()
+
+    def unmount_drives(self):
+        """Unmount all discovered drives."""
+        for drive in self.drives.values():
+            unmount_drive(drive)
+
+    def _scan_drives_internal(self):
+        """Scan removable drives for Ethos cpuid markers and populate self.drives."""
+        self.drives = {}
+
+        for drive in win32api.GetLogicalDriveStrings().split('\x00')[:-1]:
+            dtype = win32file.GetDriveType(drive)
+            if dtype != win32file.DRIVE_REMOVABLE:
+                continue
+
+            for key in ('flash', 'sdcard', 'radio'):
+                if os.path.exists(os.path.join(drive, key + ".cpuid")):
+                    # Normalise like existing code (e.g. 'H:')
+                    self.drives[key] = drive.replace("\\", "")
+
+    def scan_for_drives(self):
+        """
+        Public API for deploy tooling.
+        Rescans removable drives and returns self.drives.
+        """
+        self._scan_drives_internal()
+        return self.drives
+
+    def get_scripts_dir(self):
+        """Return the mounted scripts directory, or None."""
+        self.scan_for_drives()
+
+        # Prefer sdcard / radio over flash
+        for key in ("sdcard", "radio", "flash"):
+            root = self.drives.get(key)
+            if root:
+                scripts = os.path.join(root, "scripts")
+                if os.path.isdir(scripts):
+                    return os.path.normpath(scripts)
+
+        return None

--- a/lua/vscode-project/.vscode/scripts/debug_connection.py
+++ b/lua/vscode-project/.vscode/scripts/debug_connection.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import argparse
+import glob
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+
+
+ETHOS_VENDOR_ID = 0x0483
+
+
+def _print_header(title):
+    print(f"\n=== {title} ===")
+
+
+def _run_command(cmd):
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        print(f"$ {' '.join(cmd)}")
+        if result.stdout.strip():
+            print(result.stdout.strip())
+        if result.stderr.strip():
+            print("[stderr]")
+            print(result.stderr.strip())
+        print(f"[exit={result.returncode}]")
+    except Exception as exc:
+        print(f"$ {' '.join(cmd)}")
+        print(f"[error] {type(exc).__name__}: {exc}")
+
+
+def _list_volumes():
+    volumes = []
+    for base in ("/Volumes", "/media", "/mnt"):
+        if not os.path.isdir(base):
+            continue
+        for entry in sorted(os.listdir(base)):
+            root = os.path.join(base, entry)
+            if not os.path.isdir(root):
+                continue
+            markers = []
+            for key in ("flash", "sdcard", "radio"):
+                if os.path.exists(os.path.join(root, f"{key}.cpuid")):
+                    markers.append(key)
+            if markers or os.path.isdir(os.path.join(root, "scripts")):
+                volumes.append(
+                    {
+                        "root": root,
+                        "markers": markers,
+                        "scripts": os.path.isdir(os.path.join(root, "scripts")),
+                    }
+                )
+    return volumes
+
+
+def _list_serial_ports():
+    try:
+        from serial.tools import list_ports
+    except Exception as exc:
+        return {"error": f"{type(exc).__name__}: {exc}", "ports": []}
+
+    ports = []
+    for port in list(list_ports.comports()):
+        ports.append(
+            {
+                "device": port.device,
+                "vid": port.vid,
+                "pid": port.pid,
+                "description": port.description,
+                "interface": getattr(port, "interface", None),
+                "hwid": port.hwid,
+            }
+        )
+    return {"ports": ports}
+
+
+def _list_hid_devices():
+    try:
+        import hid
+    except Exception as exc:
+        return {"error": f"{type(exc).__name__}: {exc}", "devices": []}
+
+    devices = []
+    try:
+        for dev in hid.enumerate():
+            if dev.get("vendor_id") != ETHOS_VENDOR_ID:
+                continue
+            devices.append(
+                {
+                    "vendor_id": dev.get("vendor_id"),
+                    "product_id": dev.get("product_id"),
+                    "path": str(dev.get("path")),
+                    "product_string": dev.get("product_string"),
+                    "manufacturer_string": dev.get("manufacturer_string"),
+                    "serial_number": dev.get("serial_number"),
+                    "interface_number": dev.get("interface_number"),
+                    "usage_page": dev.get("usage_page"),
+                    "usage": dev.get("usage"),
+                }
+            )
+    except Exception as exc:
+        return {"error": f"{type(exc).__name__}: {exc}", "devices": []}
+
+    return {"devices": devices}
+
+
+def _probe_connect_module():
+    try:
+        import connect
+    except Exception as exc:
+        return {"import_error": f"{type(exc).__name__}: {exc}"}
+
+    result = {"import_ok": True}
+    radio = None
+    try:
+        radio = connect.RadioInterface()
+        result["radio_interface"] = type(radio).__name__
+        result["drives"] = dict(getattr(radio, "drives", {}))
+    except Exception as exc:
+        result["open_error"] = f"{type(exc).__name__}: {exc}"
+    finally:
+        try:
+            if radio is not None:
+                radio.close()
+        except Exception:
+            pass
+    return result
+
+
+def _switch_usb_mode(action, wait_s):
+    result = {"requested_action": action, "wait_s": wait_s}
+    try:
+        import connect
+    except Exception as exc:
+        result["import_error"] = f"{type(exc).__name__}: {exc}"
+        return result
+
+    radio = None
+    try:
+        radio = connect.RadioInterface()
+        result["radio_interface"] = type(radio).__name__
+        result["drives_before"] = dict(getattr(radio, "drives", {}))
+        if action == "start":
+            radio.start_usb_debug()
+        elif action == "stop":
+            radio.stop_usb_debug()
+        else:
+            raise ValueError(f"Unsupported action: {action}")
+        result["switch_invoked"] = True
+    except Exception as exc:
+        result["switch_error"] = f"{type(exc).__name__}: {exc}"
+        return result
+    finally:
+        try:
+            if radio is not None:
+                radio.close()
+        except Exception:
+            pass
+
+    time.sleep(wait_s)
+    result["post_wait"] = {
+        "volumes": _list_volumes(),
+        "serial": _list_serial_ports(),
+        "hid": _list_hid_devices(),
+        "dev_cu": sorted(glob.glob("/dev/cu.*")),
+        "dev_tty": sorted(glob.glob("/dev/tty.*")),
+        "connect": _probe_connect_module(),
+    }
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Debug Ethos radio USB/HID/serial state")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    parser.add_argument(
+        "--switch",
+        choices=("start", "stop"),
+        help="Actively request a USB mode switch through connect.py before collecting state.",
+    )
+    parser.add_argument(
+        "--wait",
+        type=float,
+        default=3.0,
+        help="Seconds to wait after --switch before collecting post-switch state.",
+    )
+    args = parser.parse_args()
+
+    payload = {
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "version": platform.version(),
+            "machine": platform.machine(),
+            "python": sys.version,
+        },
+        "volumes": _list_volumes(),
+        "serial": _list_serial_ports(),
+        "hid": _list_hid_devices(),
+        "connect": _probe_connect_module(),
+        "dev_cu": sorted(glob.glob("/dev/cu.*")),
+        "dev_tty": sorted(glob.glob("/dev/tty.*")),
+    }
+
+    if args.switch:
+        payload["switch_probe"] = _switch_usb_mode(args.switch, args.wait)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    _print_header("Platform")
+    print(json.dumps(payload["platform"], indent=2))
+
+    _print_header("Volumes")
+    if payload["volumes"]:
+        for item in payload["volumes"]:
+            print(json.dumps(item, indent=2))
+    else:
+        print("No candidate mounted radio volumes found.")
+
+    _print_header("Serial Ports")
+    if payload["serial"].get("error"):
+        print(payload["serial"]["error"])
+    elif payload["serial"]["ports"]:
+        for item in payload["serial"]["ports"]:
+            print(json.dumps(item, indent=2))
+    else:
+        print("No serial ports found.")
+
+    _print_header("HID Devices")
+    if payload["hid"].get("error"):
+        print(payload["hid"]["error"])
+    elif payload["hid"]["devices"]:
+        for item in payload["hid"]["devices"]:
+            print(json.dumps(item, indent=2))
+    else:
+        print(f"No HID devices found for vendor 0x{ETHOS_VENDOR_ID:04X}.")
+
+    _print_header("Connect Module Probe")
+    print(json.dumps(payload["connect"], indent=2))
+
+    if payload.get("switch_probe") is not None:
+        _print_header("Switch Probe")
+        print(json.dumps(payload["switch_probe"], indent=2))
+
+    if platform.system() == "Darwin":
+        _print_header("macOS USB Snapshot")
+        _run_command(["system_profiler", "SPUSBDataType"])
+        _print_header("macOS IORegistry Snapshot")
+        _run_command(["ioreg", "-p", "IOUSB", "-l", "-w", "0"])
+
+    _print_header("Device Nodes")
+    print("/dev/cu.*")
+    for item in payload["dev_cu"]:
+        print(item)
+    print("/dev/tty.*")
+    for item in payload["dev_tty"]:
+        print(item)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lua/vscode-project/.vscode/scripts/deploy.py
+++ b/lua/vscode-project/.vscode/scripts/deploy.py
@@ -64,6 +64,7 @@ def _connect_usb_debug(action: str):
     mod = _load_connect_module()
     if not mod:
         return False
+    ri = None
     try:
         ri = mod.RadioInterface()
         if action == 'start':
@@ -76,14 +77,30 @@ def _connect_usb_debug(action: str):
             raise ValueError(f"Unknown action: {action}")
         return True
     except BaseException as e:
-        print(f"[CONNECT] USB debug {action} failed ({type(e).__name__}: {e})")
+        err = str(e)
+        # On some macOS setups the HID interface is visible but not openable;
+        # deploy can still proceed using mounted-volume fallback.
+        if "No Ethos compatible HID device found" in err and "vendor present" in err:
+            print(
+                f"[CONNECT] USB debug {action} unavailable (HID seen but not openable in this session); "
+                "continuing with mounted-volume workflow."
+            )
+        else:
+            print(f"[CONNECT] USB debug {action} failed ({type(e).__name__}: {e})")
         return False
+    finally:
+        try:
+            if ri is not None:
+                ri.close()
+        except Exception:
+            pass
 
 def _connect_find_scripts_dir():
     """Return mounted scripts dir using connect.py drive markers, or None."""
     mod = _load_connect_module()
     if not mod:
         return None
+    ri = None
     try:
         ri = mod.RadioInterface()
         ri.scan_for_drives()
@@ -94,6 +111,12 @@ def _connect_find_scripts_dir():
                 return os.path.normpath(os.path.join(root, 'scripts'))
     except BaseException as e:
         print(f"[CONNECT] Drive scan failed ({type(e).__name__}: {e})")
+    finally:
+        try:
+            if ri is not None:
+                ri.close()
+        except Exception:
+            pass
     return None
 
 MIN_ETHOSSUITE_VERSION = "1.7.0"
@@ -988,6 +1011,26 @@ def _find_com_port(vid_hex=None, pid_hex=None, name_hint=None, allow_fuzzy_if_no
     return None
 
 
+def _find_serial_debug_port(vid_hex=None, pid_hex=None, name_hint=None):
+    """Return a likely serial debug device, preferring exact VID:PID matches."""
+    port = _find_com_port(
+        vid_hex=vid_hex,
+        pid_hex=pid_hex,
+        name_hint=name_hint,
+        allow_fuzzy_if_no_vidpid=False,
+    )
+    if port:
+        return port
+
+    # macOS sometimes reports incomplete metadata during re-enumeration.
+    return _find_com_port(
+        vid_hex=None,
+        pid_hex=None,
+        name_hint=name_hint,
+        allow_fuzzy_if_no_vidpid=True,
+    )
+
+
 def tail_serial_debug(vid=DEFAULT_SERIAL_VID, pid=DEFAULT_SERIAL_PID,
                       baud=DEFAULT_SERIAL_BAUD, retries=DEFAULT_SERIAL_RETRIES,
                       delay=DEFAULT_SERIAL_DELAY, newline=b'\n', name_hint="Serial"):
@@ -1001,11 +1044,10 @@ def tail_serial_debug(vid=DEFAULT_SERIAL_VID, pid=DEFAULT_SERIAL_PID,
 
     port = None
     for i in range(retries):
-        port = _find_com_port(vid_hex=vid, pid_hex=pid, name_hint=name_hint,
-                              allow_fuzzy_if_no_vidpid=False)
+        port = _find_serial_debug_port(vid_hex=vid, pid_hex=pid, name_hint=name_hint)
         if port:
             break
-        print(f"[SERIAL] Waiting for COM port ({i+1}/{retries})…")
+        print(f"[SERIAL] Waiting for serial port ({i+1}/{retries})…")
         time.sleep(delay)
 
     if not port:
@@ -1020,7 +1062,7 @@ def tail_serial_debug(vid=DEFAULT_SERIAL_VID, pid=DEFAULT_SERIAL_PID,
             break
         except FileNotFoundError as e:
             print(f"[SERIAL] Open attempt {attempt}/{open_attempts} -> device vanished; rescanning…")
-            port = _find_com_port(vid_hex=vid, pid_hex=pid, name_hint=name_hint)
+            port = _find_serial_debug_port(vid_hex=vid, pid_hex=pid, name_hint=name_hint)
             if not port:
                 import time as _t; _t.sleep(delay)
             continue
@@ -1360,7 +1402,7 @@ def main():
     p.add_argument('--step', dest='steps', action='append',
                    help='Additional deploy steps to run (e.g. i18n, soundpack). '
                         'Can be given multiple times.'
-    )    
+    )
 
     args = p.parse_args()
     DEPLOY_TO_RADIO = args.radio
@@ -1438,14 +1480,20 @@ def main():
 
     if args.radio and args.connect_only:
         # Just enable serial & tail logs; no copying
-        ethos_serial(config.get('ethossuite_bin'), 'start')
-
         v = str(config.get('serial_vid', DEFAULT_SERIAL_VID))
         p = str(config.get('serial_pid', DEFAULT_SERIAL_PID))
         b = int(config.get('serial_baud', DEFAULT_SERIAL_BAUD))
         r = int(config.get('serial_retries', DEFAULT_SERIAL_RETRIES))
         d = float(config.get('serial_retry_delay', DEFAULT_SERIAL_DELAY))
         nh = str(config.get('serial_name_hint', "Serial"))
+
+        existing_port = _find_serial_debug_port(vid_hex=v, pid_hex=p, name_hint=nh)
+        if existing_port:
+            print(f"[SERIAL] Existing serial debug port detected: {existing_port}; skipping HID mode switch.")
+        else:
+            rc, _, _ = ethos_serial(config.get('ethossuite_bin'), 'start')
+            if rc != 0:
+                print("[SERIAL] USB debug start unavailable; continuing to probe for a serial port anyway.")
 
         return tail_serial_debug(vid=v, pid=p, baud=b, retries=r, delay=d, name_hint=nh)
 
@@ -1489,17 +1537,23 @@ def main():
 
     if args.radio and args.radio_debug:
         _kill_previous_tail_if_any()
-        rc, _, _ = ethos_serial(config.get('ethossuite_bin'), 'start')
-        if rc != 0:
-            print("[ETHOS] First --serial start failed; retrying once…")
-            ethos_serial(config.get('ethossuite_bin'), 'start')
-
         v = str(config.get('serial_vid', DEFAULT_SERIAL_VID))
         p = str(config.get('serial_pid', DEFAULT_SERIAL_PID))
         b = int(config.get('serial_baud', DEFAULT_SERIAL_BAUD))
         r = int(config.get('serial_retries', DEFAULT_SERIAL_RETRIES))
         d = float(config.get('serial_retry_delay', DEFAULT_SERIAL_DELAY))
         nh = str(config.get('serial_name_hint', "Serial"))
+
+        existing_port = _find_serial_debug_port(vid_hex=v, pid_hex=p, name_hint=nh)
+        if existing_port:
+            print(f"[SERIAL] Existing serial debug port detected: {existing_port}; skipping HID mode switch.")
+        else:
+            rc, _, _ = ethos_serial(config.get('ethossuite_bin'), 'start')
+            if rc != 0:
+                print("[ETHOS] First --serial start failed; retrying once…")
+                rc, _, _ = ethos_serial(config.get('ethossuite_bin'), 'start')
+                if rc != 0:
+                    print("[SERIAL] USB debug start unavailable; continuing to probe for a serial port anyway.")
 
         tail_serial_debug(vid=v, pid=p, baud=b, retries=r, delay=d, name_hint=nh)
 

--- a/lua/vscode-project/.vscode/tasks.json
+++ b/lua/vscode-project/.vscode/tasks.json
@@ -227,6 +227,17 @@
       }
     },
     {
+      "label": "ethos.OpenControls",
+      "type": "process",
+      "command": "${command:ethos.openControls}",
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      }
+    },
+    {
       "label": "ethos.OpenTelemetry",
       "type": "process",
       "command": "${command:ethos.openTelemetry}",

--- a/lua/vscode-project/.vscode/tasks.json
+++ b/lua/vscode-project/.vscode/tasks.json
@@ -4,7 +4,16 @@
     {
       "label": "Deploy [SIM Files]",
       "type": "process",
-      "command": "python",
+      "command": "${workspaceFolder}/.venv/bin/python",
+      "windows": {
+        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
+      },
+      "linux": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
+      "osx": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
       "args": [
         "${workspaceFolder}/.vscode/scripts/deploy.py"
       ],
@@ -23,7 +32,16 @@
     {
       "label": "Deploy Radio",
       "type": "process",
-      "command": "python",
+      "command": "${workspaceFolder}/.venv/bin/python",
+      "windows": {
+        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
+      },
+      "linux": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
+      "osx": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
       "args": [
         "${workspaceFolder}/.vscode/scripts/deploy.py",
         "--radio"
@@ -38,7 +56,16 @@
     {
       "label": "Deploy Radio [Fast]",
       "type": "process",
-      "command": "python",
+      "command": "${workspaceFolder}/.venv/bin/python",
+      "windows": {
+        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
+      },
+      "linux": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
+      "osx": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
       "args": [
         "${workspaceFolder}/.vscode/scripts/deploy.py",
         "--fileext",
@@ -55,7 +82,16 @@
     {
       "label": "Deploy Radio + Serial Debug",
       "type": "process",
-      "command": "python",
+      "command": "${workspaceFolder}/.venv/bin/python",
+      "windows": {
+        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
+      },
+      "linux": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
+      "osx": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
       "args": [
         "${workspaceFolder}/.vscode/scripts/deploy.py",
         "--radio",
@@ -71,7 +107,16 @@
     {
       "label": "Deploy Radio + Serial Debug [Fast]",
       "type": "process",
-      "command": "python",
+      "command": "${workspaceFolder}/.venv/bin/python",
+      "windows": {
+        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
+      },
+      "linux": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
+      "osx": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
       "args": [
         "${workspaceFolder}/.vscode/scripts/deploy.py",
         "--fileext",
@@ -89,7 +134,16 @@
     {
       "label": "Radio: Serial Debug",
       "type": "process",
-      "command": "python",
+      "command": "${workspaceFolder}/.venv/bin/python",
+      "windows": {
+        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
+      },
+      "linux": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
+      "osx": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
       "args": [
         "${workspaceFolder}/.vscode/scripts/deploy.py",
         "--radio",
@@ -105,10 +159,92 @@
     {
       "label": "Clear locks",
       "type": "process",
-      "command": "python",
+      "command": "${workspaceFolder}/.venv/bin/python",
+      "windows": {
+        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
+      },
+      "linux": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
+      "osx": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
       "args": [
         "${workspaceFolder}/.vscode/scripts/deploy.py",
         "--clear-lock"
+      ],
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      }
+    },
+    {
+      "label": "Debug Radio Connection",
+      "type": "process",
+      "command": "${workspaceFolder}/.venv/bin/python",
+      "windows": {
+        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
+      },
+      "linux": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
+      "osx": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
+      "args": [
+        "${workspaceFolder}/.vscode/scripts/debug_connection.py"
+      ],
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      }
+    },
+    {
+      "label": "Debug Radio Connection: Switch To Serial",
+      "type": "process",
+      "command": "${workspaceFolder}/.venv/bin/python",
+      "windows": {
+        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
+      },
+      "linux": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
+      "osx": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
+      "args": [
+        "${workspaceFolder}/.vscode/scripts/debug_connection.py",
+        "--switch",
+        "start"
+      ],
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      }
+    },
+    {
+      "label": "Debug Radio Connection: Switch To Storage",
+      "type": "process",
+      "command": "${workspaceFolder}/.venv/bin/python",
+      "windows": {
+        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
+      },
+      "linux": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
+      "osx": {
+        "command": "${workspaceFolder}/.venv/bin/python"
+      },
+      "args": [
+        "${workspaceFolder}/.vscode/scripts/debug_connection.py",
+        "--switch",
+        "stop"
       ],
       "problemMatcher": [],
       "presentation": {

--- a/lua/vscode-project/.vscode/tasks.json
+++ b/lua/vscode-project/.vscode/tasks.json
@@ -4,15 +4,9 @@
     {
       "label": "Deploy [SIM Files]",
       "type": "process",
-      "command": "${workspaceFolder}/.venv/bin/python",
-      "windows": {
-        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
-      },
-      "linux": {
-        "command": "${workspaceFolder}/.venv/bin/python"
-      },
+      "command": "python",
       "osx": {
-        "command": "${workspaceFolder}/.venv/bin/python"
+        "command": "${config:python.defaultInterpreterPath}"
       },
       "args": [
         "${workspaceFolder}/.vscode/scripts/deploy.py"
@@ -32,15 +26,9 @@
     {
       "label": "Deploy Radio",
       "type": "process",
-      "command": "${workspaceFolder}/.venv/bin/python",
-      "windows": {
-        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
-      },
-      "linux": {
-        "command": "${workspaceFolder}/.venv/bin/python"
-      },
+      "command": "python",
       "osx": {
-        "command": "${workspaceFolder}/.venv/bin/python"
+        "command": "${config:python.defaultInterpreterPath}"
       },
       "args": [
         "${workspaceFolder}/.vscode/scripts/deploy.py",
@@ -56,15 +44,9 @@
     {
       "label": "Deploy Radio [Fast]",
       "type": "process",
-      "command": "${workspaceFolder}/.venv/bin/python",
-      "windows": {
-        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
-      },
-      "linux": {
-        "command": "${workspaceFolder}/.venv/bin/python"
-      },
+      "command": "python",
       "osx": {
-        "command": "${workspaceFolder}/.venv/bin/python"
+        "command": "${config:python.defaultInterpreterPath}"
       },
       "args": [
         "${workspaceFolder}/.vscode/scripts/deploy.py",
@@ -82,15 +64,9 @@
     {
       "label": "Deploy Radio + Serial Debug",
       "type": "process",
-      "command": "${workspaceFolder}/.venv/bin/python",
-      "windows": {
-        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
-      },
-      "linux": {
-        "command": "${workspaceFolder}/.venv/bin/python"
-      },
+      "command": "python",
       "osx": {
-        "command": "${workspaceFolder}/.venv/bin/python"
+        "command": "${config:python.defaultInterpreterPath}"
       },
       "args": [
         "${workspaceFolder}/.vscode/scripts/deploy.py",
@@ -107,15 +83,9 @@
     {
       "label": "Deploy Radio + Serial Debug [Fast]",
       "type": "process",
-      "command": "${workspaceFolder}/.venv/bin/python",
-      "windows": {
-        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
-      },
-      "linux": {
-        "command": "${workspaceFolder}/.venv/bin/python"
-      },
+      "command": "python",
       "osx": {
-        "command": "${workspaceFolder}/.venv/bin/python"
+        "command": "${config:python.defaultInterpreterPath}"
       },
       "args": [
         "${workspaceFolder}/.vscode/scripts/deploy.py",
@@ -134,15 +104,9 @@
     {
       "label": "Radio: Serial Debug",
       "type": "process",
-      "command": "${workspaceFolder}/.venv/bin/python",
-      "windows": {
-        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
-      },
-      "linux": {
-        "command": "${workspaceFolder}/.venv/bin/python"
-      },
+      "command": "python",
       "osx": {
-        "command": "${workspaceFolder}/.venv/bin/python"
+        "command": "${config:python.defaultInterpreterPath}"
       },
       "args": [
         "${workspaceFolder}/.vscode/scripts/deploy.py",
@@ -159,15 +123,9 @@
     {
       "label": "Clear locks",
       "type": "process",
-      "command": "${workspaceFolder}/.venv/bin/python",
-      "windows": {
-        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
-      },
-      "linux": {
-        "command": "${workspaceFolder}/.venv/bin/python"
-      },
+      "command": "python",
       "osx": {
-        "command": "${workspaceFolder}/.venv/bin/python"
+        "command": "${config:python.defaultInterpreterPath}"
       },
       "args": [
         "${workspaceFolder}/.vscode/scripts/deploy.py",
@@ -183,15 +141,9 @@
     {
       "label": "Debug Radio Connection",
       "type": "process",
-      "command": "${workspaceFolder}/.venv/bin/python",
-      "windows": {
-        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
-      },
-      "linux": {
-        "command": "${workspaceFolder}/.venv/bin/python"
-      },
+      "command": "python",
       "osx": {
-        "command": "${workspaceFolder}/.venv/bin/python"
+        "command": "${config:python.defaultInterpreterPath}"
       },
       "args": [
         "${workspaceFolder}/.vscode/scripts/debug_connection.py"
@@ -206,15 +158,9 @@
     {
       "label": "Debug Radio Connection: Switch To Serial",
       "type": "process",
-      "command": "${workspaceFolder}/.venv/bin/python",
-      "windows": {
-        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
-      },
-      "linux": {
-        "command": "${workspaceFolder}/.venv/bin/python"
-      },
+      "command": "python",
       "osx": {
-        "command": "${workspaceFolder}/.venv/bin/python"
+        "command": "${config:python.defaultInterpreterPath}"
       },
       "args": [
         "${workspaceFolder}/.vscode/scripts/debug_connection.py",
@@ -231,15 +177,9 @@
     {
       "label": "Debug Radio Connection: Switch To Storage",
       "type": "process",
-      "command": "${workspaceFolder}/.venv/bin/python",
-      "windows": {
-        "command": "${workspaceFolder}\\.venv\\Scripts\\python.exe"
-      },
-      "linux": {
-        "command": "${workspaceFolder}/.venv/bin/python"
-      },
+      "command": "python",
       "osx": {
-        "command": "${workspaceFolder}/.venv/bin/python"
+        "command": "${config:python.defaultInterpreterPath}"
       },
       "args": [
         "${workspaceFolder}/.vscode/scripts/debug_connection.py",

--- a/lua/vscode-project/docs/setup.md
+++ b/lua/vscode-project/docs/setup.md
@@ -24,6 +24,8 @@ The bundled `.vscode/extensions.json` recommends both the Ethos extension and th
 
 ## Python Setup
 
+### Windows
+
 PowerShell example:
 
 ```powershell
@@ -50,12 +52,31 @@ py -m pip install --upgrade pip
 py -m pip install -r requirements.txt
 ```
 
-Packages used by the deploy tooling:
+### macOS
+
+macOS requires the native `hidapi` library for USB HID support:
+
+```bash
+# Install hidapi system library
+brew install hidapi
+
+# Create and activate virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Install Python packages
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+```
+
+The `pywin32` package is platform-specific and will not install on macOS (it is skipped automatically by pip).
+
+### Packages used by the deploy tooling:
 
 - `tqdm`: progress bars during copy/update
 - `pyserial`: serial debug console support
 - `hid`: direct USB mode switching for Ethos radios
-- `pywin32`: Windows drive detection helpers used by `connect.py`
+- `pywin32`: Windows drive detection helpers used by `connect.py` (Windows only)
 - `debugpy`: keeps VS Code launch/debug integration happy
 
 Use `pyserial`, not `serial`, for the serial package install.
@@ -72,6 +93,25 @@ Windows note:
 
 - install the package above
 - copy the DLLs for your architecture into `C:\Windows\System32`
+
+## macOS Radio Deployment Support
+
+Radio deployment on macOS works by discovering radio volumes mounted at `/Volumes` and using USB HID for mode switching. The following applies:
+
+**Supported:**
+- ✓ Simulator file deployment (same as Windows/Linux)
+- ✓ Radio USB HID mode switching (`start_usb_debug()`, `stop_usb_debug()`)
+- ✓ Radio drive discovery via mounted volumes (when radio is mounted)
+- ✓ File copying to mounted radio storage
+
+**Not Available:**
+- ✗ Windows-style volume locking (FSCTL_LOCK_VOLUME) — not provided by macOS kernel
+- ✗ Direct volume ejection via `diskutil` is attempted but not guaranteed (best-effort)
+
+**Practical Notes:**
+- The Ethos radio's firmware is designed to handle filesystem operations correctly regardless of OS volume locking state
+- The deployment workflow is sequential and user-initiated, so concurrent access conflicts are unlikely
+- If a radio volume is not discovered, the fallback behavior in `deploy.py` will retry and report diagnostics
 
 If you prefer to use Ethos Suite instead of direct HID control, add an `ethossuite_bin` entry to `.vscode/deploy.json`.
 
@@ -225,9 +265,13 @@ The foundation template does not enable any of these by default.
 
 - Run `py -m pip install hid`
 
-`hidapi.dll is missing`
+`hidapi.dll is missing` (Windows)
 
 - Copy the correct `hidapi.dll` into `C:\Windows\System32`
+
+`Unable to load any of the following libraries: libhidapi...` (macOS)
+
+- On macOS, the native hidapi library must be installed: `brew install hidapi`
 
 `ethos.start` command not found
 
@@ -235,4 +279,4 @@ The foundation template does not enable any of these by default.
 
 `Python was not found`
 
-- Install Python 3 for Windows and reopen VS Code
+- Install Python 3 for your platform and reopen VS Code

--- a/lua/vscode-project/docs/setup.md
+++ b/lua/vscode-project/docs/setup.md
@@ -71,6 +71,8 @@ python -m pip install -r requirements.txt
 
 The `pywin32` package is platform-specific and will not install on macOS (it is skipped automatically by pip).
 
+In VS Code you must have installed the `Python` by Microsoft, and it is recommended to perform a complete restart of VSCode after (At least Command Palette/Developer: `Reload Window`). Then open Command Palette and use `Python: Set Interpreter`, choose the python in .venv.
+
 ### Packages used by the deploy tooling:
 
 - `tqdm`: progress bars during copy/update


### PR DESCRIPTION
Personal note: I am not an expert at all, I have just asked the AI to have a working set up on osx and we did some debugging using the new diagnostics tooling and a radio attached to have it working.

Now the AI summary:

This change set makes the radio workflow usable on macOS end-to-end:
1. Deploy to simulator works through the project virtual environment.
2. Deploy to radio works using mounted-volume fallback when needed.
3. Post-copy switch to serial/debug mode works reliably.
4. Serial debug task can attach to macOS serial devices (for example /dev/cu.usbmodem...).
5. Added diagnostics tooling to investigate USB/HID/serial state quickly.

---

**Problem Addressed**

On macOS, the workflow initially had multiple blockers:
1. VS Code task interpreter resolution failed with python.interpreterPath command not found.
2. connect logic was Windows-centric and not import-safe/useful on macOS.
3. HID detection/opening was brittle.
4. Radio deploy could copy files but fail to switch back to serial mode.
5. Debug output was noisy and made fallback behavior look like hard failure.
6. No focused tool existed to capture all relevant USB/HID/serial evidence.

---

**Key Changes**

1. **Task and interpreter reliability**
   - Updated task commands to use the project venv directly with OS overrides in [ tasks.json ](.vscode/tasks.json).
   - Set explicit interpreter path in [ settings.json ](.vscode/settings.json).

2. **Cross-platform connect refactor**
   - Introduced shared HID protocol layer in [ connect_base.py ](.vscode/scripts/connect_base.py).
   - Added Windows-specific backend in [ connect_windows.py ](.vscode/scripts/connect_windows.py).
   - Added macOS-specific backend in [ connect_macos.py ](.vscode/scripts/connect_macos.py).
   - Kept stable public entry API in [ connect.py ](.vscode/scripts/connect.py).

3. **macOS drive handling**
   - macOS drive discovery via /Volumes and cpuid markers in [ connect_macos.py ](.vscode/scripts/connect_macos.py).
   - Best-effort unmount/eject behavior via diskutil in [ connect_macos.py ](.vscode/scripts/connect_macos.py).

4. **HID detection robustness**
   - Improved HID open strategy in [ connect_base.py ](.vscode/scripts/connect_base.py): 1. Known VID/PID attempts 2. Enumerated path open attempts 3. Candidate fallback attempts
   - Improved diagnostics when HID open fails (vendor/pid summary).

5. **Deploy flow hardening**
   - Added clearer non-fatal messaging when HID is visible but not openable in [ deploy.py ](.vscode/scripts/deploy.py).
   - Improved serial port selection logic and fallback behavior in [ deploy.py ](.vscode/scripts/deploy.py).
   - Added detection for already-present serial debug port in connect-only and radio-debug paths in [ deploy.py ](.vscode/scripts/deploy.py).

6. **Critical bug fix (root cause)**
   - Fixed HID handle leak by explicitly closing RadioInterface handles after use in: - [ deploy.py ](.vscode/scripts/deploy.py) - [ debug_connection.py ](.vscode/scripts/debug_connection.py)
   - This was the key fix that allowed post-copy switch to serial mode to succeed consistently on macOS.

7. **Diagnostics tooling**
   - Added comprehensive debugger script [ debug_connection.py ](.vscode/scripts/debug_connection.py): - Volume markers - HID devices - Serial ports - Connect probe - Optional active switch probes (start/stop) - macOS system_profiler and ioreg snapshots
   - Added dedicated tasks in [ tasks.json ](.vscode/tasks.json):
     - Debug Radio Connection
     - Debug Radio Connection: Switch To Serial - Debug Radio Connection: Switch To Storage

8. **Documentation updates**
   - Added macOS setup and behavior notes in [ setup.md ](docs/setup.md), including hidapi requirement and platform capability boundaries.

---

**Validation Performed**

1. Syntax validation for updated scripts (py_compile).
2. Import and API checks for connect modules.
3. Runtime probes for HID enumeration/open behavior.
4. End-to-end Deploy Radio execution.
5. Post-deploy diagnostics confirming serial mode state:
   - volumes unmounted
   - serial device present (/dev/cu.usbmodem...)
   - HID product string shifted to serial-port state.

---

**Behavioral Outcome**

macOS now supports the intended workflow:
1. Deploy Radio copies files.
2. After copy, radio is switched back to serial/debug mode.
3. Radio: Serial Debug can attach to the serial endpoint.

---

**Windows Impact**

No intended functional regression:
1. Windows-specific FSCTL/win32 behavior remains isolated in [ connect_windows.py ](.vscode/scripts/connect_windows.py).
2. Cross-platform cleanup and handle-closing changes are neutral-to-beneficial.
3. One operational requirement: tasks now assume project-local venv exists on Windows too (path override already configured in [ tasks.json ](.vscode/tasks.json)).