### PR TITLE
Flyingeek/themes

### DIFF
--- a/lua/themes/.gitignore
+++ b/lua/themes/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+.vscode/*

--- a/lua/themes/theme-dracula/ethos_lua_manifest.json
+++ b/lua/themes/theme-dracula/ethos_lua_manifest.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "name": "Dracula",
     "key": "flyingeek-theme-Dracula",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "releaseNotes": {
         "format": "markdown",
         "content": "Dark background with vivid purple accents — inspired by the popular Dracula color scheme\n\nby [@flyingeek](https://github.com/flyingeek?tab=repositories&q=topic:ethos)\n"

--- a/lua/themes/theme-dracula/main.lua
+++ b/lua/themes/theme-dracula/main.lua
@@ -22,7 +22,7 @@ local function init()
             lcd.RGB(0x69, 0xFF, 0x94), -- ACTIVE_COLOR
             lcd.RGB(0xb8, 0xc3, 0xe4), -- INACTIVE_COLOR 0xFF, 0x80, 0xBF
             lcd.RGB(0x81, 0x5C, 0xD6), -- BUTTON_BORDER_ACTIVE_COLOR
-            lcd.RGB(0x42, 0x44, 0x50), -- BUTTON_BORDER_COLOR
+            lcd.RGB(0x34, 0x37, 0x46), -- BUTTON_BORDER_COLOR
             lcd.RGB(0xA3, 0x95, 0x14), -- WARNING_COLOR
             lcd.RGB(0x19, 0x1A, 0x21), -- SAFE_CONTRASTING_COLOR
             COLOR_BLACK,               -- TOPLCD_BGCOLOR (XE/S)

--- a/lua/themes/theme-dracula/screenshots/palette.svg
+++ b/lua/themes/theme-dracula/screenshots/palette.svg
@@ -11,6 +11,6 @@
   <rect x="243" y="0" width="24" height="24" rx="3" fill="#69FF94" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="270" y="0" width="24" height="24" rx="3" fill="#B8C3E4" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="297" y="0" width="24" height="24" rx="3" fill="#815CD6" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
-  <rect x="324" y="0" width="24" height="24" rx="3" fill="#424450" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
+  <rect x="324" y="0" width="24" height="24" rx="3" fill="#343746" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="351" y="0" width="24" height="24" rx="3" fill="#A39514" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
 </svg>

--- a/lua/themes/theme-grove/ethos_lua_manifest.json
+++ b/lua/themes/theme-grove/ethos_lua_manifest.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "name": "Grove",
     "key": "flyingeek-theme-Grove",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "releaseNotes": {
         "format": "markdown",
         "content": "Deep forest green with vivid lime highlights\n\nby [@flyingeek](https://github.com/flyingeek?tab=repositories&q=topic:ethos)\n"

--- a/lua/themes/theme-grove/main.lua
+++ b/lua/themes/theme-grove/main.lua
@@ -22,7 +22,7 @@ local function init()
             lcd.RGB(0x22, 0xD6, 0x6A), -- ACTIVE_COLOR (vivid spring green)
             lcd.RGB(0x70, 0x9C, 0x7A), -- INACTIVE_COLOR (muted sage — 3.3:1 on PAGE)
             lcd.RGB(0x22, 0xD6, 0x6A), -- BUTTON_BORDER_ACTIVE_COLOR
-            lcd.RGB(0x1C, 0x40, 0x28), -- BUTTON_BORDER_COLOR
+            lcd.RGB(0x16, 0x33, 0x20), -- BUTTON_BORDER_COLOR
             lcd.RGB(0xF4, 0xA0, 0x35), -- WARNING_COLOR (amber — caution, was ERROR_COLOR)
             lcd.RGB(0x06, 0x1A, 0x0E), -- SAFE_CONTRASTING_COLOR
             COLOR_BLACK,               -- TOPLCD_BGCOLOR (XE/S)

--- a/lua/themes/theme-grove/screenshots/palette.svg
+++ b/lua/themes/theme-grove/screenshots/palette.svg
@@ -11,6 +11,6 @@
   <rect x="243" y="0" width="24" height="24" rx="3" fill="#22D66A" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="270" y="0" width="24" height="24" rx="3" fill="#709C7A" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="297" y="0" width="24" height="24" rx="3" fill="#22D66A" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
-  <rect x="324" y="0" width="24" height="24" rx="3" fill="#1C4028" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
+  <rect x="324" y="0" width="24" height="24" rx="3" fill="#163320" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="351" y="0" width="24" height="24" rx="3" fill="#F4A035" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
 </svg>

--- a/lua/themes/theme-matrix/ethos_lua_manifest.json
+++ b/lua/themes/theme-matrix/ethos_lua_manifest.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "name": "Matrix",
     "key": "flyingeek-theme-Matrix",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "releaseNotes": {
         "format": "markdown",
         "content": "Green-on-black terminal theme inspired by the Matrix digital rain\n\nby [@flyingeek](https://github.com/flyingeek?tab=repositories&q=topic:ethos)\n"

--- a/lua/themes/theme-matrix/main.lua
+++ b/lua/themes/theme-matrix/main.lua
@@ -22,7 +22,7 @@ local function init()
             lcd.RGB(0x00, 0xFF, 0x41), -- 12 ACTIVE_COLOR (bright matrix green)
             lcd.RGB(0x00, 0x6B, 0x1A), -- 13 INACTIVE_COLOR (dim dark green — intentionally ghosted)
             lcd.RGB(0x00, 0xFF, 0x41), -- 14 BUTTON_BORDER_ACTIVE_COLOR
-            lcd.RGB(0x00, 0x33, 0x00), -- 15 BUTTON_BORDER_COLOR (same as SECONDARY_BGCOLOR)
+            lcd.RGB(0x00, 0x27, 0x00), -- 15 BUTTON_BORDER_COLOR
             lcd.RGB(0xFF, 0xAA, 0x00), -- 16 WARNING_COLOR (amber)
             COLOR_BLACK,               -- 17 SAFE_CONTRASTING_COLOR (black on chartreuse)
             COLOR_BLACK,               -- 18 TOPLCD_BGCOLOR (XE/S)

--- a/lua/themes/theme-matrix/screenshots/palette.svg
+++ b/lua/themes/theme-matrix/screenshots/palette.svg
@@ -13,7 +13,7 @@
   <rect x="297" y="0" width="24" height="24" rx="3" fill="#00FF41" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="324" y="0" width="24" height="24" rx="3" fill="#006B1A" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="351" y="0" width="24" height="24" rx="3" fill="#00FF41" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
-  <rect x="378" y="0" width="24" height="24" rx="3" fill="#003300" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
+  <rect x="378" y="0" width="24" height="24" rx="3" fill="#002700" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="405" y="0" width="24" height="24" rx="3" fill="#FFAA00" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="432" y="0" width="24" height="24" rx="3" fill="#000000" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="459" y="0" width="24" height="24" rx="3" fill="#000000" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>

--- a/lua/themes/theme-moebius/ethos_lua_manifest.json
+++ b/lua/themes/theme-moebius/ethos_lua_manifest.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "name": "Dracula Moebius Red",
     "key": "flyingeek-theme-Moebius",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "releaseNotes": {
         "format": "markdown",
         "content": "Dracula variant with deep red accents\n\nby [@flyingeek](https://github.com/flyingeek?tab=repositories&q=topic:ethos)\n"

--- a/lua/themes/theme-moebius/main.lua
+++ b/lua/themes/theme-moebius/main.lua
@@ -22,7 +22,7 @@ local function init()
             lcd.RGB(0x69, 0xFF, 0x94), -- ACTIVE_COLOR
             lcd.RGB(0xb8, 0xc3, 0xe4), -- INACTIVE_COLOR 0xFF, 0x80, 0xBF
             lcd.RGB(0x81, 0x5C, 0xD6), -- BUTTON_BORDER_ACTIVE_COLOR
-            lcd.RGB(0x42, 0x44, 0x50), -- BUTTON_BORDER_COLOR
+            lcd.RGB(0x34, 0x37, 0x46), -- BUTTON_BORDER_COLOR
             lcd.RGB(0xA3, 0x95, 0x14), -- WARNING_COLOR
             lcd.RGB(0x19, 0x1A, 0x21), -- SAFE_CONTRASTING_COLOR
             COLOR_BLACK,               -- TOPLCD_BGCOLOR (XE/S)

--- a/lua/themes/theme-moebius/screenshots/palette.svg
+++ b/lua/themes/theme-moebius/screenshots/palette.svg
@@ -11,6 +11,6 @@
   <rect x="243" y="0" width="24" height="24" rx="3" fill="#69FF94" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="270" y="0" width="24" height="24" rx="3" fill="#B8C3E4" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="297" y="0" width="24" height="24" rx="3" fill="#815CD6" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
-  <rect x="324" y="0" width="24" height="24" rx="3" fill="#424450" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
+  <rect x="324" y="0" width="24" height="24" rx="3" fill="#343746" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="351" y="0" width="24" height="24" rx="3" fill="#A39514" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
 </svg>

--- a/lua/themes/theme-monokai/ethos_lua_manifest.json
+++ b/lua/themes/theme-monokai/ethos_lua_manifest.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "name": "Monokai",
     "key": "flyingeek-theme-Monokai",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "releaseNotes": {
         "format": "markdown",
         "content": "Warm olive canvas with cyan and lime green accents — inspired by the iconic Monokai editor theme\n\nby [@flyingeek](https://github.com/flyingeek?tab=repositories&q=topic:ethos)\n"

--- a/lua/themes/theme-monokai/main.lua
+++ b/lua/themes/theme-monokai/main.lua
@@ -22,7 +22,7 @@ local function init()
             lcd.RGB(0xE6, 0xDB, 0x74), -- 12 ACTIVE_COLOR             (Monokai yellow — 12.9:1 on page)
             lcd.RGB(0x75, 0x71, 0x5E), -- 13 INACTIVE_COLOR           (comment gray — 3.4:1 on page)
             lcd.RGB(0x66, 0xD9, 0xE8), -- 14 BUTTON_BORDER_ACTIVE_COLOR (matches HIGHLIGHT)
-            lcd.RGB(0x49, 0x48, 0x3E), -- 15 BUTTON_BORDER_COLOR      (matches SECONDARY_BGCOLOR)
+            lcd.RGB(0x3D, 0x3C, 0x24), -- 15 BUTTON_BORDER_COLOR
             lcd.RGB(0xFD, 0x97, 0x1F), -- 16 WARNING_COLOR            (Monokai orange — 7.5:1 on canvas)
             lcd.RGB(0x1A, 0x1B, 0x16), -- 17 SAFE_CONTRASTING_COLOR   (near-black on lime)
             COLOR_BLACK,               -- 18 TOPLCD_BGCOLOR (XE/S)

--- a/lua/themes/theme-monokai/screenshots/palette.svg
+++ b/lua/themes/theme-monokai/screenshots/palette.svg
@@ -13,7 +13,7 @@
   <rect x="297" y="0" width="24" height="24" rx="3" fill="#E6DB74" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="324" y="0" width="24" height="24" rx="3" fill="#75715E" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="351" y="0" width="24" height="24" rx="3" fill="#66D9E8" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
-  <rect x="378" y="0" width="24" height="24" rx="3" fill="#49483E" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
+  <rect x="378" y="0" width="24" height="24" rx="3" fill="#3D3C24" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="405" y="0" width="24" height="24" rx="3" fill="#FD971F" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="432" y="0" width="24" height="24" rx="3" fill="#1A1B16" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="459" y="0" width="24" height="24" rx="3" fill="#000000" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>

--- a/lua/themes/theme-night-ops/ethos_lua_manifest.json
+++ b/lua/themes/theme-night-ops/ethos_lua_manifest.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "name": "Night Ops",
     "key": "flyingeek-theme-NightOp",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "releaseNotes": {
         "format": "markdown",
         "content": "Red-on-black cockpit style for low-light flying\n\nby [@flyingeek](https://github.com/flyingeek?tab=repositories&q=topic:ethos)\n"

--- a/lua/themes/theme-night-ops/main.lua
+++ b/lua/themes/theme-night-ops/main.lua
@@ -23,7 +23,7 @@ local function init()
             lcd.RGB(0xFF, 0x44, 0x00), -- ACTIVE_COLOR (= HIGHLIGHT_COLOR)
             lcd.RGB(0x5A, 0x18, 0x00), -- INACTIVE_COLOR (dim dark ember)
             lcd.RGB(0xFF, 0x44, 0x00), -- BUTTON_BORDER_ACTIVE_COLOR
-            lcd.RGB(0x6B, 0x10, 0x00), -- BUTTON_BORDER_COLOR
+            lcd.RGB(0x40, 0x0A, 0x00), -- BUTTON_BORDER_COLOR
             lcd.RGB(0xFF, 0xAA, 0x00), -- WARNING_COLOR (cockpit amber — hue ~40°, 7.7:1 on PRIMARY)
             COLOR_BLACK,               -- SAFE_CONTRASTING_COLOR (9.9:1 on cockpit green)
             COLOR_BLACK,               -- TOPLCD_BGCOLOR (XE/S)

--- a/lua/themes/theme-night-ops/screenshots/palette.svg
+++ b/lua/themes/theme-night-ops/screenshots/palette.svg
@@ -11,6 +11,6 @@
   <rect x="243" y="0" width="24" height="24" rx="3" fill="#FF4400" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="270" y="0" width="24" height="24" rx="3" fill="#5A1800" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="297" y="0" width="24" height="24" rx="3" fill="#FF4400" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
-  <rect x="324" y="0" width="24" height="24" rx="3" fill="#6B1000" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
+  <rect x="324" y="0" width="24" height="24" rx="3" fill="#400A00" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="351" y="0" width="24" height="24" rx="3" fill="#FFAA00" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
 </svg>

--- a/lua/themes/theme-ocean/ethos_lua_manifest.json
+++ b/lua/themes/theme-ocean/ethos_lua_manifest.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "name": "Ocean",
     "key": "flyingeek-theme-Ocean",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "releaseNotes": {
         "format": "markdown",
         "content": "Deep navy blue with royal blue highlights\n\nby [@flyingeek](https://github.com/flyingeek?tab=repositories&q=topic:ethos)\n"

--- a/lua/themes/theme-ocean/main.lua
+++ b/lua/themes/theme-ocean/main.lua
@@ -22,7 +22,7 @@ local function init()
             lcd.RGB(0x44, 0x88, 0xFF), -- ACTIVE_COLOR (bleu royal)
             lcd.RGB(0x2A, 0x50, 0x80), -- INACTIVE_COLOR (bleu terne)
             lcd.RGB(0x44, 0x88, 0xFF), -- BUTTON_BORDER_ACTIVE_COLOR
-            lcd.RGB(0x2C, 0x44, 0x68), -- BUTTON_BORDER_COLOR
+            lcd.RGB(0x20, 0x31, 0x5B), -- BUTTON_BORDER_COLOR
             lcd.RGB(0xFF, 0x8C, 0x00), -- WARNING_COLOR (warning orange — 6.9:1 on PRIMARY, 4.3:1 on SECONDARY)
             COLOR_BLACK,               -- SAFE_CONTRASTING_COLOR
             COLOR_BLACK,               -- TOPLCD_BGCOLOR (XE/S)

--- a/lua/themes/theme-ocean/screenshots/palette.svg
+++ b/lua/themes/theme-ocean/screenshots/palette.svg
@@ -11,6 +11,6 @@
   <rect x="243" y="0" width="24" height="24" rx="3" fill="#4488FF" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="270" y="0" width="24" height="24" rx="3" fill="#2A5080" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="297" y="0" width="24" height="24" rx="3" fill="#4488FF" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
-  <rect x="324" y="0" width="24" height="24" rx="3" fill="#2C4468" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
+  <rect x="324" y="0" width="24" height="24" rx="3" fill="#20315B" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="351" y="0" width="24" height="24" rx="3" fill="#FF8C00" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
 </svg>

--- a/lua/themes/theme-synthwave/ethos_lua_manifest.json
+++ b/lua/themes/theme-synthwave/ethos_lua_manifest.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "name": "Synthwave",
     "key": "flyingeek-theme-Synthwave",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "releaseNotes": {
         "format": "markdown",
         "content": "Deep indigo dark theme with neon hot-pink highlights and electric-cyan accents — inspired by the synthwave / retrowave aesthetic\n\nby [@flyingeek](https://github.com/flyingeek?tab=repositories&q=topic:ethos)\n"

--- a/lua/themes/theme-synthwave/main.lua
+++ b/lua/themes/theme-synthwave/main.lua
@@ -22,7 +22,7 @@ local function init()
             lcd.RGB(0x00, 0xFF, 0x9F), -- 12 ACTIVE_COLOR               (neon mint, same as SAFE)
             lcd.RGB(0x90, 0x90, 0xC8), -- 13 INACTIVE_COLOR             (muted lavender)
             lcd.RGB(0x00, 0xAA, 0xCC), -- 14 BUTTON_BORDER_ACTIVE_COLOR (dimmed cyan)
-            lcd.RGB(0x1E, 0x1B, 0x5E), -- 15 BUTTON_BORDER_COLOR        (indigo, same as SECONDARY_BGCOLOR)
+            lcd.RGB(0x15, 0x13, 0x42), -- 15 BUTTON_BORDER_COLOR
             lcd.RGB(0xFF, 0x8C, 0x1A), -- 16 WARNING_COLOR              (neon orange)
             lcd.RGB(0x06, 0x05, 0x1A), -- 17 SAFE_CONTRASTING_COLOR     (near-black on mint)
             COLOR_BLACK,               -- 18 TOPLCD_BGCOLOR (XE/S)

--- a/lua/themes/theme-synthwave/screenshots/palette.svg
+++ b/lua/themes/theme-synthwave/screenshots/palette.svg
@@ -13,7 +13,7 @@
   <rect x="297" y="0" width="24" height="24" rx="3" fill="#00FF9F" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="324" y="0" width="24" height="24" rx="3" fill="#9090C8" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="351" y="0" width="24" height="24" rx="3" fill="#00AACC" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
-  <rect x="378" y="0" width="24" height="24" rx="3" fill="#1E1B5E" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
+  <rect x="378" y="0" width="24" height="24" rx="3" fill="#151342" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="405" y="0" width="24" height="24" rx="3" fill="#FF8C1A" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="432" y="0" width="24" height="24" rx="3" fill="#06051A" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="459" y="0" width="24" height="24" rx="3" fill="#000000" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>

--- a/lua/themes/theme-tricolore/ethos_lua_manifest.json
+++ b/lua/themes/theme-tricolore/ethos_lua_manifest.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "name": "Tricolore",
     "key": "flyingeek-theme-Tricol",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "releaseNotes": {
         "format": "markdown",
         "content": "Deep navy with French red accents\n\nby [@flyingeek](https://github.com/flyingeek?tab=repositories&q=topic:ethos)\n"

--- a/lua/themes/theme-tricolore/main.lua
+++ b/lua/themes/theme-tricolore/main.lua
@@ -22,7 +22,7 @@ local function init()
             lcd.RGB(0xED, 0x29, 0x39), -- ACTIVE_COLOR (French red)
             lcd.RGB(0x3A, 0x4E, 0x8A), -- INACTIVE_COLOR (muted navy)
             lcd.RGB(0xED, 0x29, 0x39), -- BUTTON_BORDER_ACTIVE_COLOR (French red)
-            lcd.RGB(0x26, 0x3A, 0x84), -- BUTTON_BORDER_COLOR
+            lcd.RGB(0x1C, 0x2B, 0x63), -- BUTTON_BORDER_COLOR
             lcd.RGB(0xFF, 0x6B, 0x2B), -- WARNING_COLOR (orange — caution, was ERROR_COLOR)
             COLOR_BLACK,               -- SAFE_CONTRASTING_COLOR (10.2:1 on sky blue)
             COLOR_BLACK,               -- TOPLCD_BGCOLOR (XE/S)

--- a/lua/themes/theme-tricolore/screenshots/palette.svg
+++ b/lua/themes/theme-tricolore/screenshots/palette.svg
@@ -11,6 +11,6 @@
   <rect x="243" y="0" width="24" height="24" rx="3" fill="#ED2939" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="270" y="0" width="24" height="24" rx="3" fill="#3A4E8A" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="297" y="0" width="24" height="24" rx="3" fill="#ED2939" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
-  <rect x="324" y="0" width="24" height="24" rx="3" fill="#263A84" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
+  <rect x="324" y="0" width="24" height="24" rx="3" fill="#1C2B63" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="351" y="0" width="24" height="24" rx="3" fill="#FF6B2B" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
 </svg>

--- a/lua/themes/theme-tropical-sunset/ethos_lua_manifest.json
+++ b/lua/themes/theme-tropical-sunset/ethos_lua_manifest.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "name": "Tropical Sunset",
     "key": "flyingeek-theme-Sunset",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "releaseNotes": {
         "format": "markdown",
         "content": "Warm magenta-purple canvas with orange and golden yellow\n\nby [@flyingeek](https://github.com/flyingeek?tab=repositories&q=topic:ethos)\n"

--- a/lua/themes/theme-tropical-sunset/main.lua
+++ b/lua/themes/theme-tropical-sunset/main.lua
@@ -22,7 +22,7 @@ local function init()
             lcd.RGB(0xFF, 0x77, 0x00), -- ACTIVE_COLOR (= HIGHLIGHT_COLOR)
             lcd.RGB(0x80, 0x40, 0x90), -- INACTIVE_COLOR (muted violet)
             lcd.RGB(0xFF, 0x77, 0x00), -- BUTTON_BORDER_ACTIVE_COLOR
-            lcd.RGB(0x3A, 0x00, 0x60), -- BUTTON_BORDER_COLOR
+            lcd.RGB(0x33, 0x00, 0x54), -- BUTTON_BORDER_COLOR
             lcd.RGB(0xFF, 0xC2, 0x00), -- WARNING_COLOR (golden amber — hue ~46° distinct from orange HIGHLIGHT, 7.2:1 on PRIMARY)
             lcd.RGB(0x1A, 0x00, 0x28), -- SAFE_CONTRASTING_COLOR
             COLOR_BLACK,               -- TOPLCD_BGCOLOR (XE/S)

--- a/lua/themes/theme-tropical-sunset/screenshots/palette.svg
+++ b/lua/themes/theme-tropical-sunset/screenshots/palette.svg
@@ -11,6 +11,6 @@
   <rect x="243" y="0" width="24" height="24" rx="3" fill="#FF7700" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="270" y="0" width="24" height="24" rx="3" fill="#804090" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="297" y="0" width="24" height="24" rx="3" fill="#FF7700" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
-  <rect x="324" y="0" width="24" height="24" rx="3" fill="#3A0060" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
+  <rect x="324" y="0" width="24" height="24" rx="3" fill="#330054" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
   <rect x="351" y="0" width="24" height="24" rx="3" fill="#FFC200" stroke="#ffffff" stroke-opacity="0.15" stroke-width="0.5"/>
 </svg>


### PR DESCRIPTION
Checklist popup needs a different color for SECONDARY_BGCOLOR and BUTTON_BORDER_COLOR
- All dark themes needed a color change
- palette updated
- version incremented to 1.0.1